### PR TITLE
[EM-8831] Address ERR_HTTP_HEADERS_SENT errors in camo

### DIFF
--- a/server.coffee
+++ b/server.coffee
@@ -45,14 +45,15 @@ default_security_headers =
 
 four_oh_four = (resp, msg, url) ->
   error_log "#{msg}: #{url?.format() or 'unknown'}"
-  resp.writeHead 404,
-    expires: "0"
-    "Cache-Control": "no-cache, no-store, private, must-revalidate"
-    "X-Frame-Options"           : default_security_headers["X-Frame-Options"]
-    "X-XSS-Protection"          : default_security_headers["X-XSS-Protection"]
-    "X-Content-Type-Options"    : default_security_headers["X-Content-Type-Options"]
-    "Content-Security-Policy"   : default_security_headers["Content-Security-Policy"]
-    "Strict-Transport-Security" : default_security_headers["Strict-Transport-Security"]
+  unless resp.headersSent
+    resp.writeHead 404,
+      expires: "0"
+      "Cache-Control": "no-cache, no-store, private, must-revalidate"
+      "X-Frame-Options"           : default_security_headers["X-Frame-Options"]
+      "X-XSS-Protection"          : default_security_headers["X-XSS-Protection"]
+      "X-Content-Type-Options"    : default_security_headers["X-Content-Type-Options"]
+      "Content-Security-Policy"   : default_security_headers["Content-Security-Policy"]
+      "Strict-Transport-Security" : default_security_headers["Strict-Transport-Security"]
 
   finish resp, "Not Found"
 

--- a/server.js
+++ b/server.js
@@ -69,15 +69,17 @@
 
   four_oh_four = function(resp, msg, url) {
     error_log(`${msg}: ${(url != null ? url.format() : void 0) || 'unknown'}`);
-    resp.writeHead(404, {
-      expires: "0",
-      "Cache-Control": "no-cache, no-store, private, must-revalidate",
-      "X-Frame-Options": default_security_headers["X-Frame-Options"],
-      "X-XSS-Protection": default_security_headers["X-XSS-Protection"],
-      "X-Content-Type-Options": default_security_headers["X-Content-Type-Options"],
-      "Content-Security-Policy": default_security_headers["Content-Security-Policy"],
-      "Strict-Transport-Security": default_security_headers["Strict-Transport-Security"]
-    });
+    if (!resp.headersSent) {
+      resp.writeHead(404, {
+        expires: "0",
+        "Cache-Control": "no-cache, no-store, private, must-revalidate",
+        "X-Frame-Options": default_security_headers["X-Frame-Options"],
+        "X-XSS-Protection": default_security_headers["X-XSS-Protection"],
+        "X-Content-Type-Options": default_security_headers["X-Content-Type-Options"],
+        "Content-Security-Policy": default_security_headers["Content-Security-Policy"],
+        "Strict-Transport-Security": default_security_headers["Strict-Transport-Security"]
+      });
+    }
     return finish(resp, "Not Found");
   };
 


### PR DESCRIPTION
Jira: https://zendesk.atlassian.net/browse/EM-8831

This PR is to address these errors that was found when we see invalid links that hit the socket timeout. The container would error out once one of these errors would come in causing constant container restarts and service downtimes.
```
[2024-01-29T21:53:00.529Z] Socket timeout: http://files.angeloni.com.br/resources/_img/email_img/img_bottom.gif
[2024-01-29T21:53:00.530Z] Request aborted
[2024-01-29T21:53:00.530Z] Socket timeout: http://files.angeloni.com.br/resources/_img/email_img/img_bottom.gif
[2024-01-29T21:53:00.530Z] Request aborted
[2024-01-29T21:53:00.530Z] Socket timeout: http://files.angeloni.com.br/resources/_img/email_img/img_bottom.gif
[2024-01-29T21:53:00.531Z] Request aborted
[2024-01-29T21:53:00.532Z] Client Request error Error: socket hang up
    at connResetException (node:internal/errors:787:14)
    at Socket.socketCloseListener (node:_http_client:468:25)
    at Socket.emit (node:events:526:35)
    at TCP.<anonymous> (node:net:337:12): http://files.angeloni.com.br/resources/_img/email_img/img_bottom.gif
node:_http_server:345
    throw new ERR_HTTP_HEADERS_SENT('write');
    ^

Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent to the client
    at ServerResponse.writeHead (node:_http_server:345:11)
    at four_oh_four (/app/server.js:72:10)
    at ClientRequest.<anonymous> (/app/server.js:220:16)
    at ClientRequest.emit (node:events:514:28)
    at Socket.socketCloseListener (node:_http_client:468:11)
    at Socket.emit (node:events:526:35)
    at TCP.<anonymous> (node:net:337:12) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
```

This code was tested in staging to confirm that it will not cause any container restarts when invalid links are sent in and was load tested with 1000 get requests to the invalid links, a valid link, and a normal 404 error and no container restarts were observed. 

_** note that the container restarts in this dashboard were from the previous test to confirm that this error would happen and the load test was ran on email-image-proxy-6694f89b98-9745n **_

Dashboard:  https://zendesk.datadoghq.com/dashboard/7xm-ajf-g7u/email-image-proxy?refresh_mode=paused&tpl_var_pod%5B0%5D=pod998&view=spans&from_ts=1706743618532&to_ts=1706744784000&live=false

### Next steps
Once this change is merged to open a pr in https://github.com/zendesk/email-image-proxy to remove the 120 second timeout and to update the camo image